### PR TITLE
Fixing EPFL LDAP quirk

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,18 +1,19 @@
 ##########################################
-# Software Engineering 2014 Configuration
+# Software Engineering 2015 Configuration
 ##########################################
 
 # Student spreadsheet configuration
 spreadsheet:
-    title: SwEng 2014 Students
+    title: SwEng Students 2015
     students_worksheet: Students
     teams_worksheet: Teams
 
 # Github organization configuration
 organization:
-    name: sweng-epfl-2014
-    staff-team-id: 1234567 # Get this from the team URL in the web interface
-    class-team-id: 2345678
+    name: sweng-epfl-2015
+    # these are the correct IDs for 2015
+    staff-team-id: 1754583
+    class-team-id: 1760748
 
     homework-team-prefix: "SwEng Team - "
     homework-repo-prefix: "sweng-team-"
@@ -20,6 +21,7 @@ organization:
     exam-repo-prefix: "sweng-student-"
 
 google_auth:
+    # do this for your own google auth credentials
     client_id: 123.apps.googleusercontent.com
     # This should be stored secretly somewhere...
     client_secret: XYZ

--- a/setup_venv.sh
+++ b/setup_venv.sh
@@ -5,6 +5,13 @@
 
 set -e
 
+official_name=official
+official_repo="https://github.com/EPFL-IC/sweng-management"
+if ! git remote show "$official_name" &>/dev/null; then
+    git remote add "$official_name" "$official_repo"
+    git fetch "$official_name"
+fi
+
 # Temporarily download Virtualenv's source code
 mkdir virtualenv
 curl https://pypi.python.org/packages/source/v/virtualenv/virtualenv-13.1.2.tar.gz | tar -xz -C virtualenv --strip-components=1

--- a/swengmgmt/students.py
+++ b/swengmgmt/students.py
@@ -254,7 +254,7 @@ class SwEngClass(object):
 
         # Populate the Github team
         for student in team.students:
-            if team.gh_team.add_member(student.github_id):
+            if team.gh_team.invite(student.github_id):
                 logging.info("Added %s (%s) to team %s."
                              % (student.github_id, student, team))
             else:
@@ -291,7 +291,7 @@ class SwEngClass(object):
             logging.info("Created exam team for student %s." % student)
 
         # Populate the Github team
-        if student.gh_team.add_member(student.github_id):
+        if student.gh_team.invite(student.github_id):
             logging.info("Added %s (%s) to his/her exam repo."
                          % (student.github_id, student))
 
@@ -306,7 +306,7 @@ class SwEngClass(object):
 
         for team in self.teams.itervalues():
             for student in team.students:
-                class_team.add_member(student.github_id)
+                class_team.invite(student.github_id)
             class_team.add_repo(team.gh_repo.full_name)
 
     def closeTeamReposToClass(self, github_org):


### PR DESCRIPTION
Some students have multiple LDAP entries, and some of those entries have _multiple_ and _weird_ gaspars (e.g. GASPAR@UNIT, where unit is xdesk, py, or something strange). This commit fixes these quirks.
