### PR TITLE
Rearranging logic for repo creation

### DIFF
--- a/swengmgmt/students.py
+++ b/swengmgmt/students.py
@@ -287,8 +287,11 @@ class SwEngClass(object):
                 "".join([self._org_config["exam-team-prefix"], student.gaspar,
                          " (%s)" % student.name]),
                 permission="push")
-            student.gh_team.add_repo(student.gh_repo.full_name)
+
             logging.info("Created exam team for student %s." % student)
+
+        if not student.gh_team.has_repo(student.gh_repo.full_name):
+            student.gh_team.add_repo(student.gh_repo.full_name)
 
         # Populate the Github team
         if student.gh_team.invite(student.github_id):


### PR DESCRIPTION
The logic for repo creation had to be adjusted to accommodate multiple individual homework assignments for the same team.

Before this commit, a repo would not be created if the team would already exist. This is not intended. For example, if one creates a 'hw1' for the class with the script and then tries to create a 'hw2', the repos will be created, but the students' teams won't be added to their respective repos.

This commit solves the above problem.

This may happen again for team creation, but I won't be able to test this well until later in the class.
