### PR TITLE
Adding new commands

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML>=3.11
 gdata>=2.0.18
-github3.py>=0.9.1
+github3.py>=0.9.4
 python-ldap>=2.4.16
 requests>=2.4.1
 uritemplate.py>=0.3.0

--- a/swengmgmt/commands.py
+++ b/swengmgmt/commands.py
@@ -190,6 +190,17 @@ class StudentsListCommand(GithubCommand):
         elif args.format == "tabular":
             self._printTabular(student_list)
 
+class StaffPermCommand(GithubCommand):
+    arg_name = "staff-perm"
+
+    def register(self, parser):
+        parser.add_argument("permission", choices=["push", "pull"],
+                            help="The permission to set.")
+
+    def execute(self, args):
+        super(StaffPermCommand, self).execute(args)
+        self.sweng_class.changeStaffPermissions(
+            github_org=self.github_org, permission=args.permission)
 
 class StudentsPermCommand(GithubCommand):
     """Update student permissions."""
@@ -369,7 +380,7 @@ class ClassClose(GithubCommand):
 ALL_COMMANDS = [StudentsListCommand, StudentsPermCommand, StudentsCreateCommand,
                 StudentsDeleteCommand, TeamsListCommand, TeamsPermCommand,
                 TeamsCreateCommand, TeamsDeleteCommand, RepairCommand,
-                ClassOpen, ClassClose]
+                ClassOpen, ClassClose, StaffPermCommand]
 
 
 def registerGlobalArguments(parser):

--- a/swengmgmt/commands.py
+++ b/swengmgmt/commands.py
@@ -228,6 +228,29 @@ class StudentsPermCommand(GithubCommand):
         for student in student_list:
             student.updateTeamPermission(args.permission)
 
+class StudentsHideCommand(GithubCommand):
+    """Hide the student's repository, if it exists, by removing them as a collaborator."""
+
+    arg_name = "students-hide"
+
+    def register(self, parser):
+        parser.add_argument("--exclude", nargs="*",
+                    help="A list of students to exclude.")
+        parser.add_argument("students", nargs="*",
+                            help="A list of students to consider. "
+                            "Leave empty to include everyone.")
+
+    def execute(self, args):
+        if not (args.students or self.confirmClassOperation()):
+            return
+
+        super(StudentsHideCommand, self).execute(args)
+
+        query = students.StudentQuery(args.students, args.exclude)
+        student_list = self.sweng_class.findStudents(query)
+
+        for student in student_list:
+            self.sweng_class.hideExamRepo(student, self.github_org)
 
 class StudentsCreateCommand(GithubCommand):
     """Create exam repos for students."""
@@ -380,7 +403,7 @@ class ClassClose(GithubCommand):
 ALL_COMMANDS = [StudentsListCommand, StudentsPermCommand, StudentsCreateCommand,
                 StudentsDeleteCommand, TeamsListCommand, TeamsPermCommand,
                 TeamsCreateCommand, TeamsDeleteCommand, RepairCommand,
-                ClassOpen, ClassClose, StaffPermCommand]
+                ClassOpen, ClassClose, StaffPermCommand, StudentsHideCommand]
 
 
 def registerGlobalArguments(parser):

--- a/swengmgmt/students.py
+++ b/swengmgmt/students.py
@@ -158,6 +158,11 @@ class SwEngClass(object):
             "".join([re.escape(self._org_config["homework-repo-prefix"]),
                      r"(.*)"]))
 
+    def changeStaffPermissions(self, github_org, permission):
+        staff_team = github_org.team(self._org_config["staff-team-id"])
+        staff_team.edit(name=staff_team.name,
+                        permission=permission)
+
     def populateFromSpreadsheet(self, student_sheet, team_sheet):
         student_list = student_sheet.getStudentList(SwEngStudent)
         self.students = { student.gaspar: student for student in student_list }

--- a/swengmgmt/students.py
+++ b/swengmgmt/students.py
@@ -273,6 +273,30 @@ class SwEngClass(object):
 
         team.gh_team.edit(team.gh_team.name, permission='push')
 
+    def hideExamRepo(self, student, github_org):
+        if student.gh_repo:
+            if student.gh_team:
+                staff_team = github_org.team(self._org_config["staff-team-id"])
+                if staff_team in (a for a in student.gh_repo.iter_teams()):
+                    if not student.gh_team.remove_repo(student.gh_repo):
+                            #"".join([self._org_config["exam-repo-prefix"], student.gaspar])):
+                        logging.warning("Unable to remove {st} as a collaborator for their repo".format(
+                            st=student
+                        ))
+                    else:
+                        logging.info("Hid {repo} from student {st}".format(
+                            st=student, repo=student.gh_repo
+                        ))
+                else:
+                    logging.warning("Not hiding student '{st}' from repo because staff team '{staff}' is not on the team".format(
+                        st=student, staff=staff_team
+                    ))
+            else:
+                st="Student '{st}' has a gh_repo, but no team!".format(st=student)
+                logging.error(st)
+        else:
+            logging.info("Student {st} does not have a repo. Skipping".format(st=student))
+
     def createExamRepo(self, student, github_org):
         # Create the repo
         if not student.gh_repo:


### PR DESCRIPTION
Some of the github commands were deprecated, such as the new way of using the permissions on repositories (i.e. change the team permission only does it for _future_ repositories, not current ones).

This covers the above command, plus an additional one for doing permissions changes for the staff team.

I also bumped the github3 version to the latest one, just to be up-to-date.
