### PR TITLE
Adding read-only option to repo create

### DIFF
--- a/swengmgmt/commands.py
+++ b/swengmgmt/commands.py
@@ -264,6 +264,8 @@ class StudentsCreateCommand(GithubCommand):
     def register(self, parser):
         parser.add_argument("--exclude", nargs="*",
                             help="A list of students to exclude.")
+        parser.add_argument("--read-only", default=False, action='store_true',
+                            help="Make this repo read-only for students")
         parser.add_argument("students", nargs="*",
                             help="A list of students to consider. "
                             "Leave empty to include everyone.")
@@ -275,7 +277,7 @@ class StudentsCreateCommand(GithubCommand):
         student_list = self.sweng_class.findStudents(query)
         
         for student in student_list:
-            self.sweng_class.createExamRepo(student, self.github_org)
+            self.sweng_class.createExamRepo(student, self.github_org, read_only=args.read_only)
 
 class StudentsPopulateCommand(GithubCommand):
     """Force push a given repository to students' exam repositories"""

--- a/swengmgmt/commands.py
+++ b/swengmgmt/commands.py
@@ -319,10 +319,22 @@ class StudentsDeleteCommand(GithubCommand):
     arg_name = "students-delete"
 
     def register(self, parser):
-        pass
+        parser.add_argument("--exclude", nargs="*",
+                            help="A list of students to exclude.")
+        parser.add_argument("students", nargs="*",
+                            help="A list of students to consider. "
+                                 "Leave empty to include everyone.")
 
     def execute(self, args):
-        pass
+        if not (args.students or self.confirmClassOperation()):
+            return
+        super(StudentsDeleteCommand, self).execute(args)
+
+        query = students.StudentQuery(args.students, args.exclude)
+        student_list = self.sweng_class.findStudents(query)
+
+        for student in student_list:
+            self.sweng_class.deleteExamRepo(student, self.github_org)
 
 
 class TeamsListCommand(GithubCommand):

--- a/swengmgmt/students.py
+++ b/swengmgmt/students.py
@@ -317,6 +317,13 @@ class SwEngClass(object):
                 "git remote rm student"
             ))
 
+    def deleteExamRepo(self, student, github_org):
+        if student.gh_repo:
+            if student.gh_repo.delete():
+                logging.info("Deleting exam repo for student {}".format(student))
+            else:
+                logging.warn("Student {} doesn't have an exam repo".format(student))
+
     def createExamRepo(self, student, github_org, add_to_team=True):
         # Create the repo
         if not student.gh_repo:

--- a/swengmgmt/students.py
+++ b/swengmgmt/students.py
@@ -324,7 +324,7 @@ class SwEngClass(object):
             else:
                 logging.warn("Student {} doesn't have an exam repo".format(student))
 
-    def createExamRepo(self, student, github_org, add_to_team=True):
+    def createExamRepo(self, student, github_org, add_to_team=True, read_only=False):
         # Create the repo
         if not student.gh_repo:
             student.gh_repo = github_org.create_repo(
@@ -347,7 +347,12 @@ class SwEngClass(object):
             logging.info("Created exam team for student %s." % student)
 
         if add_to_team and not student.gh_team.has_repo(student.gh_repo.full_name):
+            old_perm = student.repo_access
+            if read_only:
+                student.updateTeamPermission("pull")
             student.gh_team.add_repo(student.gh_repo.full_name)
+            if read_only:
+                student.updateTeamPermission(old_perm)
 
         # Populate the Github team
         if not student.gh_team.is_member(student.github_id) and student.gh_team.invite(student.github_id):


### PR DESCRIPTION
This is useful for overloading students-create for giving students read-only access to their repositories.
For example, the usual workflow is
1. release repos to all students
2. hide repos from all students
3. grade
4. re-release the repos to all students, but with read-only access (i.e. to "publish" their grade)
